### PR TITLE
Make the boolean conditionals examples equivalent

### DIFF
--- a/workflow/boolean-conditions.md
+++ b/workflow/boolean-conditions.md
@@ -4,8 +4,8 @@ Avoid using `>=` and `<=` unless necessary. It's faster to use a simpler compari
 
 ```js
 // slow
-// two boolean conditions: `=== -1` and `> -1`
-array.indexOf(i) >= -1
+// two boolean conditions: `=== 0` and `> 0`
+array.indexOf(i) >= 0
 
 // fast
 // just one boolean condition: `!== -1`


### PR DESCRIPTION
`array.indexOf(i) >= -1` will return `true` when `array.indexOf(i)` is -1 or greater. `array.indexOf(i) !== -1` will return `true` when `array.indexOf(i)` is not -1. Since `Array.prototype.indexOf` returns values starting from -1, that is equivalent to `array.indexOf(i) >= 0`. This pull request makes both expressions equivalent.
